### PR TITLE
Исправление запуска api в docker

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -7,7 +7,7 @@ build:
 
 .PHONY: run
 run: build
-	@docker run --rm -it -p 127.0.0.1:8080:8080 backend
+	@docker compose -f ../docker-compose.yml up -d api
 
 .PHONY: containers
 containers:


### PR DESCRIPTION
При запуске `make` в `backend/` контейнер не видел БД.